### PR TITLE
Allow filter property

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ i-amp-el {
     /* elements starting with i-amp- are banned
 }
 .boo {
-    filter: gray(.5); /* filter is banned */
+    transition: height 0.5s; /* non-GPU-accelerated transition properties are banned */
     color: red !important; /* important is banned */
 }
 ```

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = plugin('postcss-amp', () => {
       selector.parent.removeChild(selector);
     });
     // Removing properties
-    root.walkDecls(/behavior|-moz-binding|filter/, decl => {
+    root.walkDecls(/behavior|-moz-binding/, decl => {
       let { parent } = decl;
       parent.removeChild(decl);
       // remove whole selector if it empty

--- a/index.test.js
+++ b/index.test.js
@@ -20,12 +20,8 @@ it('removes i-amp- tag names selectors', () => {
   );
 });
 
-it('removes behavior, -moz-binding and filter properties', () => {
-  return run(
-    'a { behavior: none; -moz-binding: inherit; filter: grayscale(50); }',
-    '',
-    {}
-  );
+it('removes behavior and -moz-binding properties', () => {
+  return run('a { behavior: none; -moz-binding: inherit; }', '', {});
 });
 
 it('removes non-GPU transition', () => {


### PR DESCRIPTION
As noted in [issue #99](https://github.com/tinovyatkin/postcss-amp/issues/99) [AMP now allows for `filter` to be used](https://github.com/ampproject/amphtml/issues/11611). This PR stops it from being stripped out.

I also updated the test as well as replacing `filter` in the README (I can delete it from the README but thought it was nice to have an example of a few things getting removed after run).

fixes #99